### PR TITLE
Fix listing of example unacceptable behavior

### DIFF
--- a/fixtures/code-of-conduct.md
+++ b/fixtures/code-of-conduct.md
@@ -6,12 +6,13 @@ We are committed to making participation in this project a harassment-free exper
 
 Examples of unacceptable behavior by participants include:
 
-The use of sexualized language or imagery
-Personal attacks
-Trolling or insulting/derogatory comments
-Public or private harassment
-Publishing other's private information, such as physical or electronic addresses, without explicit permission
-Other unethical or unprofessional conduct
+* The use of sexualized language or imagery
+* Personal attacks
+* Trolling or insulting/derogatory comments
+* Public or private harassment
+* Publishing other's private information, such as physical or electronic addresses, without explicit permission
+* Other unethical or unprofessional conduct
+
 Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
 
 By adopting this Code of Conduct, project maintainers commit themselves to fairly and consistently applying these principles to every aspect of managing this project. Project maintainers who do not follow or enforce the Code of Conduct may be permanently removed from the project team.


### PR DESCRIPTION
As is the previous version rendered the list as a single mashup paragraph