### PR TITLE
Prefer repo specific email address

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -25,7 +25,7 @@ if (cli.flags.email) {
 function findEmail() {
 	let email;
 	try {
-		email = execa.sync('git', ['config', '--global', 'user.email']).stdout.trim();
+		email = execa.sync('git', ['config', 'user.email']).stdout.trim();
 	} catch (err) {}
 
 	return email;


### PR DESCRIPTION
Use the email address specified in the local repo config, reverting to
the global config, and finally a prompt if none are found.

At the moment the current implementation uses the globally set
email address and ignores and repo specific configuration.

The resolves an issue for those that have `user.useconfigonly=true`
set globally, or are overriding their email on a per-repo basis.