### PR TITLE
Add --uppercase and --underscore flags

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -53,7 +53,7 @@ function findEmail() {
 	return email;
 }
 
-function write(filepath, email, fileToRemove = null) {
+function write(filepath, email, fileToRemove) {
 	const src = fs.readFileSync(path.join(__dirname, 'vendor/code_of_conduct.md'), 'utf8');
 	fs.writeFileSync(filepath, src.replace('[INSERT EMAIL ADDRESS]', email));
 
@@ -86,12 +86,13 @@ function init() {
 		const existingSrc = fs.readFileSync(existing, 'utf8');
 		const email = Array.from(getEmails(existingSrc))[0];
 
-		if (existing === filepath) {
-			write(filepath, cli.flags.email || email);
-		} else {
+		if (cli.flags.underscore || cli.flags.uppercase) {
 			// If the existing file is different from the
 			// intended file, pass it in for removal
-			write(filepath, cli.flags.email || email, existing);
+			write(filepath, cli.flags.email || email, ((existing !== filepath) && existing) || null);
+		} else {
+			// Otherwise, just update the original
+			write(existing, cli.flags.email || email);
 		}
 
 		console.log(`${logSymbols.success} Updated your Code of Conduct`);

--- a/cli.js
+++ b/cli.js
@@ -13,13 +13,36 @@ const logSymbols = require('log-symbols');
 
 const config = new Conf();
 
+let filepath = 'code-of-conduct.md';
+
 const cli = meow(`
 	Usage
 	  $ conduct
-`);
+
+	Options
+	  -c, --uppercase  Use all uppercase letters
+	  -u, --underscore Use undescores instead of dashes
+
+	Example
+	  $ conduct -cu
+
+`, {
+	alias: {
+		c: 'uppercase',
+		u: 'underscore'
+	}
+});
 
 if (cli.flags.email) {
 	config.set('email', cli.flags.email);
+}
+
+if (cli.flags.uppercase) {
+	filepath = filepath.toUpperCase();
+}
+
+if (cli.flags.underscore) {
+	filepath = filepath.replace(/-/g, '_');
 }
 
 function findEmail() {
@@ -45,21 +68,23 @@ function init() {
 	const results = globby.sync([
 		'code_of_conduct.*',
 		'code-of-conduct.*',
+		'CODE_OF_CONDUCT.*',
+		'CODE-OF-CONDUCT.*',
 		'.github/code_of_conduct.*',
-		'.github/code-of-conduct.*'
-	], {nocase: true});
+		'.github/code-of-conduct.*',
+		'.github/CODE_OF_CONDUCT.*',
+		'.github/CODE-OF-CONDUCT.*'
+	], {nocase: false});
 
 	// Update existing
 	if (results.length > 0) {
-		const filepath = results[0];
-		const existingSrc = fs.readFileSync(filepath, 'utf8');
+		const existing = results[0];
+		const existingSrc = fs.readFileSync(existing, 'utf8');
 		const email = Array.from(getEmails(existingSrc))[0];
 		write(filepath, cli.flags.email || email);
 		console.log(`${logSymbols.success} Updated your Code of Conduct`);
 		return;
 	}
-
-	const filepath = 'code-of-conduct.md';
 
 	if (config.has('email')) {
 		generate(filepath, config.get('email'));

--- a/cli.js
+++ b/cli.js
@@ -22,10 +22,6 @@ const cli = meow(`
 	Options
 	  -c, --uppercase  Use all uppercase letters
 	  -u, --underscore Use undescores instead of dashes
-
-	Example
-	  $ conduct -cu
-
 `, {
 	alias: {
 		c: 'uppercase',

--- a/cli.js
+++ b/cli.js
@@ -14,7 +14,7 @@ const logSymbols = require('log-symbols');
 const config = new Conf();
 
 let filename = 'code-of-conduct';
-let extension = '.md';
+const extension = '.md';
 
 const cli = meow(`
 	Usage
@@ -86,13 +86,14 @@ function init() {
 		const existingSrc = fs.readFileSync(existing, 'utf8');
 		const email = Array.from(getEmails(existingSrc))[0];
 
-		if (existing !== filepath) {
-			// if the existing file is different from the
+		if (existing === filepath) {
+			write(filepath, cli.flags.email || email);
+		} else {
+			// If the existing file is different from the
 			// intended file, pass it in for removal
 			write(filepath, cli.flags.email || email, existing);
-		} else {
-			write(filepath, cli.flags.email || email);
 		}
+
 		console.log(`${logSymbols.success} Updated your Code of Conduct`);
 		return;
 	}

--- a/cli.js
+++ b/cli.js
@@ -21,8 +21,8 @@ const cli = meow(`
 	  $ conduct
 
 	Options
-	  --uppercase, -c   Use uppercase characters in the filename
-	  --underscore, -u  Use underscores instead of dashes in the filename
+	  --uppercase, -c   Use uppercase characters (e.g. CODE-OF-CONDUCT.md)
+	  --underscore, -u  Use underscores instead of dashes (e.g. code_of_conduct.md)
 `, {
 	alias: {
 		c: 'uppercase',
@@ -72,13 +72,9 @@ function init() {
 	const results = globby.sync([
 		'code_of_conduct.*',
 		'code-of-conduct.*',
-		'CODE_OF_CONDUCT.*',
-		'CODE-OF-CONDUCT.*',
 		'.github/code_of_conduct.*',
-		'.github/code-of-conduct.*',
-		'.github/CODE_OF_CONDUCT.*',
-		'.github/CODE-OF-CONDUCT.*'
-	], {nocase: false});
+		'.github/code-of-conduct.*'
+	], {nocase: true});
 
 	// Update existing
 	if (results.length > 0) {
@@ -89,7 +85,7 @@ function init() {
 		if (cli.flags.underscore || cli.flags.uppercase) {
 			// If the existing file is different from the
 			// intended file, pass it in for removal
-			write(filepath, cli.flags.email || email, ((existing !== filepath) && existing) || null);
+			write(filepath, cli.flags.email || email, existing !== filepath && existing);
 		} else {
 			// Otherwise, just update the original
 			write(existing, cli.flags.email || email);

--- a/cli.js
+++ b/cli.js
@@ -13,7 +13,8 @@ const logSymbols = require('log-symbols');
 
 const config = new Conf();
 
-let filepath = 'code-of-conduct.md';
+let filename = 'code-of-conduct';
+let extension = '.md';
 
 const cli = meow(`
 	Usage
@@ -34,12 +35,14 @@ if (cli.flags.email) {
 }
 
 if (cli.flags.uppercase) {
-	filepath = filepath.toUpperCase();
+	filename = filename.toUpperCase();
 }
 
 if (cli.flags.underscore) {
-	filepath = filepath.replace(/-/g, '_');
+	filename = filename.replace(/-/g, '_');
 }
+
+const filepath = `${filename}${extension}`;
 
 function findEmail() {
 	let email;
@@ -84,8 +87,8 @@ function init() {
 		const email = Array.from(getEmails(existingSrc))[0];
 
 		if (existing !== filepath) {
-			// if the existing file name is different from the
-			// intended file name, pass it in for removal
+			// if the existing file is different from the
+			// intended file, pass it in for removal
 			write(filepath, cli.flags.email || email, existing);
 		} else {
 			write(filepath, cli.flags.email || email);

--- a/cli.js
+++ b/cli.js
@@ -54,9 +54,14 @@ function findEmail() {
 	return email;
 }
 
-function write(filepath, email) {
+function write(filepath, email, fileToRemove = null) {
 	const src = fs.readFileSync(path.join(__dirname, 'vendor/code_of_conduct.md'), 'utf8');
 	fs.writeFileSync(filepath, src.replace('[INSERT EMAIL ADDRESS]', email));
+
+	if (fileToRemove) {
+		fs.unlinkSync(fileToRemove);
+		console.log(`${logSymbols.warning} Deleted ${fileToRemove}`);
+	}
 }
 
 function generate(filepath, email) {
@@ -81,7 +86,14 @@ function init() {
 		const existing = results[0];
 		const existingSrc = fs.readFileSync(existing, 'utf8');
 		const email = Array.from(getEmails(existingSrc))[0];
-		write(filepath, cli.flags.email || email);
+
+		if (existing !== filepath) {
+			// if the existing file name is different from the
+			// intended file name, pass it in for removal
+			write(filepath, cli.flags.email || email, existing);
+		} else {
+			write(filepath, cli.flags.email || email);
+		}
 		console.log(`${logSymbols.success} Updated your Code of Conduct`);
 		return;
 	}

--- a/cli.js
+++ b/cli.js
@@ -21,8 +21,8 @@ const cli = meow(`
 	  $ conduct
 
 	Options
-	  -c, --uppercase  Use all uppercase letters
-	  -u, --underscore Use undescores instead of dashes
+	  --uppercase, -c   Use uppercase characters in the filename
+	  --underscore, -u  Use underscores instead of dashes in the filename
 `, {
 	alias: {
 		c: 'uppercase',

--- a/readme.md
+++ b/readme.md
@@ -30,12 +30,21 @@ $ npm install --global conduct
 ## Usage
 
 ```
-$ conduct
+Usage
+  $ conduct
+
+Options
+  --uppercase, -c   Use uppercase characters (e.g. CODE-OF-CONDUCT.md)
+  --underscore, -u  Use underscores instead of dashes (e.g. code_of_conduct.md)
 ```
 
 You can also use this to update an existing Code of Conduct.
 
 When generating a new Code of Conduct it will try to infer your email to use as contact email. If it can't, it will prompt for it. The email is persisted and only asked once. You can force update the email with `conduct --email=your@email.com`. When updating an existing Code of Conduct, it will use the existing contact email unless you pass the `--email` flag.
+
+## Options
+
+
 
 
 ## Code of Conduct

--- a/readme.md
+++ b/readme.md
@@ -42,10 +42,6 @@ You can also use this to update an existing Code of Conduct.
 
 When generating a new Code of Conduct it will try to infer your email to use as contact email. If it can't, it will prompt for it. The email is persisted and only asked once. You can force update the email with `conduct --email=your@email.com`. When updating an existing Code of Conduct, it will use the existing contact email unless you pass the `--email` flag.
 
-## Options
-
-
-
 
 ## Code of Conduct
 


### PR DESCRIPTION
For the sake of flexibility, I've added two little flags: `--underscore` (alias `-u`) and `--uppercase` (alias `-c`). As the names suggest, `--underscore` uses `_` instead of `-` in `code-of-conduct.md`, whereas `--uppercase` just makes everything capitalised, so it becomes `CODE-OF-CONDUCT.md` (file extension is not affected, though that's up for debate). You can also combine the two flags, obviously.

I felt like this is useful because some people prefer having their project metadata files in a particular style, and the uppercase style is one I come across often, as is the underscore style. Hopefully I didn't make a mess of the source code.