### PR TITLE
Add option to specify output directory

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -10,6 +10,7 @@ const chalk = require('chalk');
 const Conf = require('conf');
 const execa = require('execa');
 const logSymbols = require('log-symbols');
+const makeDir = require('make-dir');
 
 const config = new Conf({
 	defaults: {
@@ -111,6 +112,7 @@ function findEmail() {
 function write(filepath, email, fileToRemove) {
 	const target = `vendor/code-of-conduct.${config.get('language')}.md`;
 	const src = fs.readFileSync(path.join(__dirname, target), 'utf8');
+	makeDir.sync(path.dirname(filepath));
 	fs.writeFileSync(filepath, src.replace('[INSERT EMAIL ADDRESS]', email));
 
 	if (fileToRemove) {

--- a/cli.js
+++ b/cli.js
@@ -169,7 +169,7 @@ async function init() {
 		const answers = await inquirer.prompt([{
 			type: 'input',
 			name: 'email',
-			message: `Couldn't infer your email. Please enter your email:`,
+			message: 'Couldn\'t infer your email. Please enter your email:',
 			validate: x => x.includes('@')
 		}]);
 		generate(filePath, answers.email);

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
 		"globby": "^8.0.1",
 		"inquirer": "^6.0.0",
 		"log-symbols": "^2.2.0",
+		"make-dir": "^1.3.0",
 		"meow": "^5.0.0"
 	},
 	"devDependencies": {

--- a/test.js
+++ b/test.js
@@ -92,3 +92,11 @@ test.serial('generate with directory', async t => {
 	t.true(src.includes('In the interest of fostering'));
 	t.true(src.includes('foo@bar.com'));
 });
+
+test.serial('generate with directory (directory missing)', async t => {
+	const cwd = tempy.directory();
+	await execa(bin, ['--email=foo@bar.com', '--directory=test'], {cwd});
+	const src = fs.readFileSync(path.join(cwd, 'test', 'code-of-conduct.md'), 'utf8');
+	t.true(src.includes('In the interest of fostering'));
+	t.true(src.includes('foo@bar.com'));
+});

--- a/test.js
+++ b/test.js
@@ -83,3 +83,12 @@ test.serial('update language', async t => {
 	// Cleanup
 	await setLanguage('en', cwd);
 });
+
+test.serial('generate with directory', async t => {
+	const cwd = tempy.directory();
+	fs.mkdirSync(path.join(cwd, 'test'));
+	await execa(bin, ['--email=foo@bar.com', '--directory=test'], {cwd});
+	const src = fs.readFileSync(path.join(cwd, 'test', 'code-of-conduct.md'), 'utf8');
+	t.true(src.includes('In the interest of fostering'));
+	t.true(src.includes('foo@bar.com'));
+});

--- a/test.js
+++ b/test.js
@@ -8,7 +8,7 @@ import tempy from 'tempy';
 const bin = path.join(__dirname, 'cli.js');
 const fixture = fs.readFileSync(path.join(__dirname, 'fixtures/code-of-conduct.md'), 'utf8');
 
-const setLanguage = async (language, cwd) => {
+const setLanguage = (language, cwd) => {
 	return execa(bin, [`--language=${language}`], {cwd});
 };
 


### PR DESCRIPTION
Use `--directory` to specify output directory.

This change does not ensure that the directory exists.

Closes #7 